### PR TITLE
Add ability to update UI from USB stick

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+while true; do 
+    cd ui
+    python main.py --text
+    sleep 1
+    cd ..
+    python update_ui.py
+done

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -131,9 +131,6 @@ class Reducers():
     def shutdown(self, state, value):
         return state.copy(shutting_down = True)
 
-    def halt_ui(self, state, value):
-        return state.copy(halt_ui = value)
-
     def update_ui(self, state, value):
         return state.copy(update_ui = value)
 

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -131,6 +131,12 @@ class Reducers():
     def shutdown(self, state, value):
         return state.copy(shutting_down = True)
 
+    def halt_ui(self, state, value):
+        return state.copy(halt_ui = value)
+
+    def update_ui(self, state, value):
+        return state.copy(update_ui = value)
+
 
 def sort_books(books):
     return sorted(books, key=lambda book: book['data'].filename)

--- a/ui/config.rc
+++ b/ui/config.rc
@@ -5,6 +5,9 @@ log_file = canute.log
 library_dir = ~/books/
 # where usb sticks will be automounted
 usb_dir = /media/
+# where the software is - needed for ui updates
+install_dir = ~/canute-ui/ui/
+archive_dir = ~/
 
 [user]
 user_name = pi

--- a/ui/config_loader.py
+++ b/ui/config_loader.py
@@ -1,9 +1,10 @@
 import os.path
 from ConfigParser import ConfigParser
 
-def load ():
+config_file = 'config.rc'
+def load (config_file = config_file):
     config = ConfigParser()
-    config.read('config.rc')
+    config.read(config_file)
     library_dir = config.get('files', 'library_dir')
     config.set('files', 'library_dir', os.path.expanduser(library_dir))
     if not config.has_section('comms'):

--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -1,7 +1,6 @@
 from frozendict import frozendict
 from functools import partial
 import pickle
-import json
 import logging
 log = logging.getLogger(__name__)
 

--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -19,20 +19,22 @@ initial_state = frozendict({
     'replacing_library' : False,
     'backing_up_log'    : False,
     'shutting_down'     : False,
+    'halt_ui'           : False,
     'warming_up'        : False,
     'resetting_display' : False,
+    'update_ui'         : False,
     'display'           : frozendict({'width': 40, 'height': 9}),
 })
 
 state_file = 'state.pkl'
 
-def read():
-    log.debug('reading initial state')
+def read(state_file = state_file):
+    log.debug('reading initial state from %s' % state_file)
     try:
         with open(state_file) as fh:
             state = pickle.load(fh)
             return state
-    except:
+    except IOError:
         log.debug('error reading state file, using hard-coded initial state')
         return initial_state
 

--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -1,6 +1,7 @@
 from frozendict import frozendict
 from functools import partial
 import pickle
+import json
 import logging
 log = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ def read(state_file = state_file):
         with open(state_file) as fh:
             state = pickle.load(fh)
             return state
-    except IOError:
+    except:
         log.debug('error reading state file, using hard-coded initial state')
         return initial_state
 
@@ -52,3 +53,9 @@ def write(state):
     write_state['shutting_down']     = False
     with open(state_file, 'w') as fh:
         pickle.dump(frozendict(write_state), fh)
+
+if __name__ == '__main__':
+    import os
+    path = os.path.abspath(__file__)
+    dir_path = os.path.dirname(path)
+    print(read(state_file = dir_path + "/state.pkl")['update_ui'])

--- a/ui/main.py
+++ b/ui/main.py
@@ -82,7 +82,9 @@ def button_loop(driver):
             if not driver.is_ok():
                 log.debug('shutting down due to GUI closed')
                 store.dispatch(actions.shutdown())
-            if state['shutting_down'] or state['halt_ui']:
+            if state['shutting_down'] or state['update_ui'] == 'in progress':
+                log.debug("shutting down due to state change")
+                initial_state.write(state)
                 quit = True
         if type(location) == int:
             location = 'book'
@@ -92,8 +94,6 @@ def button_loop(driver):
                 store.dispatch(button_bindings[location][_type][_id]())
             except KeyError:
                 log.debug('no binding for key {}, {} press'.format(_id, _type))
-
-    store.dispatch(actions.halt_ui(False))
 
 
 def handle_changes(driver, config):
@@ -204,10 +204,9 @@ def change_files(config, state):
         log.info("update ui = start")
         if utility.find_ui_update(config):
             store.dispatch(actions.update_ui('in progress'))
-            store.dispatch(actions.halt_ui(True))
         else:
             log.info("update not found")
-            store.dispatch(actions.update_ui('done'))
+            store.dispatch(actions.update_ui('failed'))
 
 
 def format_title(title, width, page_number, total_pages):

--- a/ui/main.py
+++ b/ui/main.py
@@ -57,6 +57,12 @@ def run(driver, config):
     store.dispatch(actions.init(init_state))
     sync_library(init_state, config.get('files', 'library_dir'))
     store.subscribe(partial(handle_changes, driver, config))
+    
+    # if we startup and update_ui is still 'in progress' then we are using the old state file
+    # and update has failed
+    if init_state["update_ui"] == "in progress":
+        store.dispatch(actions.update_ui('failed'))
+
     # since handle_changes subscription happens after init and sync_library it
     # may not have triggered. so we trigger it here. if we put it before init
     # it will start of by rendering a possibly invalid state. sync_library
@@ -64,14 +70,6 @@ def run(driver, config):
     # guarantee of the subscription triggering if subscribed before that.
     store.dispatch(actions.trigger())
     button_loop(driver)
-    run_update(config)
-
-
-def run_update(config):
-    state = store.get_state()
-    if state['update_ui'] == 'in progress':
-        store.dispatch(actions.update_ui('done')) # set as done, if it fails, need to be able to try again
-        utility.update_ui(config)
 
 
 def button_loop(driver):

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -9,6 +9,7 @@ menu = OrderedDict([
     ('backup log to USB stick'        , partial(actions.backup_log, 'start')),
     ('run warm up routine'            , partial(actions.warm_up, 'start')),
     ('reset display'                  , partial(actions.reset_display, 'start')),
+    ('update UI from USB stick'       , partial(actions.update_ui, 'start')),
 ])
 
 menu_titles_braille = map(utility.alphas_to_pin_nums, menu)

--- a/ui/utility.py
+++ b/ui/utility.py
@@ -9,17 +9,56 @@ import os
 import re
 import logging
 import functools
+import tarfile
+import shutil
+from datetime import datetime
 log = logging.getLogger(__name__)
 
 class FormfeedConversionException(Exception): pass
 class LinefeedConversionException(Exception): pass
 
-def find_firmware(directory):
-    '''recursively look for firmware, return first one found'''
-    firmware_file = 'canute-firmware.zip'
-    for root, dirnames, filenames in os.walk(directory):
+def update_ui(config):
+    '''
+    updates the ui by:
+
+    * archiving the ui directory in config's install_dir
+    * untar.gz new archive into place
+    '''
+    log.info("updating UI")
+    ui_file = find_ui_update(config)
+
+    install_dir = config.get('files', 'install_dir')
+    install_dir = os.path.expanduser(install_dir)
+
+    archive_dir = config.get('files', 'archive_dir')
+    archive_dir = os.path.expanduser(archive_dir)
+
+    # archive old ui
+    log.info("archiving %s to %s" % (install_dir, archive_dir))
+    """
+    archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
+    shutil.move(install_dir, archive_dir)
+
+    # untar new ui
+    log.info("untar")
+    with tarfile.open(ui_file, 'r:*') as archive:
+        archive.extractall(install_dir)
+    """
+
+
+def find_ui_update(config):
+    '''
+    recursively look for firmware in the usb_dir,
+    firmware file is called canute-ui.tar.gz
+    returns first one found
+    '''
+    usb_dir = config.get('files', 'usb_dir')
+    ui_file = 'canute-ui.tar.gz'
+
+    log.info("update UI - looking for new ui in %s" % usb_dir)
+    for root, dirnames, filenames in os.walk(usb_dir):
         for filename in filenames:
-                if filename == firmware_file:
+                if filename == ui_file:
                     return(os.path.join(root, filename))
 
 def find_files(directory, extensions):

--- a/ui/utility.py
+++ b/ui/utility.py
@@ -17,35 +17,6 @@ log = logging.getLogger(__name__)
 class FormfeedConversionException(Exception): pass
 class LinefeedConversionException(Exception): pass
 
-def update_ui(config):
-    '''
-    updates the ui by:
-
-    * archiving the ui directory in config's install_dir
-    * untar.gz new archive into place
-    '''
-    log.info("updating UI")
-    ui_file = find_ui_update(config)
-
-    install_dir = config.get('files', 'install_dir')
-    install_dir = os.path.expanduser(install_dir)
-
-    archive_dir = config.get('files', 'archive_dir')
-    archive_dir = os.path.expanduser(archive_dir)
-
-    # archive old ui
-    log.info("archiving %s to %s" % (install_dir, archive_dir))
-    """
-    archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
-    shutil.move(install_dir, archive_dir)
-
-    # untar new ui
-    log.info("untar")
-    with tarfile.open(ui_file, 'r:*') as archive:
-        archive.extractall(install_dir)
-    """
-
-
 def find_ui_update(config):
     '''
     recursively look for firmware in the usb_dir,

--- a/update_ui.py
+++ b/update_ui.py
@@ -1,71 +1,71 @@
 from subprocess import Popen, PIPE
 from ui.utility import find_ui_update
 from ui.config_loader import load
+from ui.setup_logs import setup_logs
 import os
 import logging
 from datetime import datetime
 import shutil
 import tarfile
 
-'''
-UI updater
-'''
-
-# setup the logs
-log_format = logging.Formatter(
-        '%(asctime)s - %(name)-16s - %(levelname)-8s - %(message)s')
-log = logging.getLogger('')
-log.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-ch.setFormatter(log_format)
-log.addHandler(ch)
-fh = logging.FileHandler('update.log')
-fh.setFormatter(log_format)
-log.addHandler(fh)
+config = load("ui/config.rc")
+log = setup_logs(config, logging.DEBUG)
 
 '''
 checks the state, if state is set to in_progress, get the update file and continue
 '''
-log.info("checking state")
-process = Popen(["python", "ui/initial_state.py"], stdout=PIPE)
-(update_state, err) = process.communicate()
-exit_code = process.wait()
+def need_update():
+    log.info("checking state")
+    process = Popen(["python", "ui/initial_state.py"], stdout=PIPE)
+    (update_state, err) = process.communicate()
+    exit_code = process.wait()
 
-if update_state is None:
-    log.warning("couldn't open state")
-    exit(1)
+    if update_state is None:
+        log.warning("couldn't open state")
+        return False
 
-update_state = update_state.strip()
-log.info("update_ui = %s" % update_state)
-if update_state != "in progress":
-    exit(0)
+    update_state = update_state.strip()
+    log.info("update_ui = %s" % update_state)
+    if update_state == "in progress":
+        return True
 
-config = load("ui/config.rc")
-update_file = find_ui_update(config)
-if update_file is None:
-    log.warning("no update file found")
-    exit(1)
-
-log.info("found update file: %s" % update_file)
 
 '''
-everything is ready, so:
-    * archive the ui directory in config's install_dir
-    * untar.gz new archive into place
+archive the ui directory in config's install_dir
 '''
+def archive():
+    install_dir = config.get('files', 'install_dir')
+    install_dir = os.path.expanduser(install_dir)
 
-install_dir = config.get('files', 'install_dir')
-install_dir = os.path.expanduser(install_dir)
+    archive_dir = config.get('files', 'archive_dir')
+    archive_dir = os.path.expanduser(archive_dir)
 
-archive_dir = config.get('files', 'archive_dir')
-archive_dir = os.path.expanduser(archive_dir)
+    log.info("archiving %s to %s" % (install_dir, archive_dir))
+    archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
+    shutil.move(install_dir, archive_dir)
 
-# archive old ui
-log.info("archiving %s to %s" % (install_dir, archive_dir))
-archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
-shutil.move(install_dir, archive_dir)
 
-# untar new ui
-log.info("untar to %s" % install_dir)
-with tarfile.open(update_file, 'r:*') as archive:
-    archive.extractall(install_dir)
+'''
+untar.gz new archive into place
+'''
+def untar(update_file):
+    # untar new ui
+    log.info("untar to %s" % install_dir)
+    with tarfile.open(update_file, 'r:*') as archive:
+        archive.extractall(install_dir)
+
+
+if __name__ == '__main__':
+    if not need_update():
+        exit(0)
+
+    update_file = find_ui_update(config)
+    if update_file is None:
+        log.warning("no update file found")
+        exit(1)
+
+    log.info("found update file: %s" % update_file)
+
+    archive()
+
+    untar(update_file)

--- a/update_ui.py
+++ b/update_ui.py
@@ -32,8 +32,9 @@ def need_update():
 
 '''
 archive the ui directory in config's install_dir
+then untar.gz new archive into place
 '''
-def archive():
+def archive_and_untar():
     install_dir = config.get('files', 'install_dir')
     install_dir = os.path.expanduser(install_dir)
 
@@ -44,11 +45,6 @@ def archive():
     archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
     shutil.move(install_dir, archive_dir)
 
-
-'''
-untar.gz new archive into place
-'''
-def untar(update_file):
     # untar new ui
     log.info("untar to %s" % install_dir)
     with tarfile.open(update_file, 'r:*') as archive:
@@ -66,6 +62,4 @@ if __name__ == '__main__':
 
     log.info("found update file: %s" % update_file)
 
-    archive()
-
-    untar(update_file)
+    archive_and_untar()

--- a/update_ui.py
+++ b/update_ui.py
@@ -1,0 +1,71 @@
+from subprocess import Popen, PIPE
+from ui.utility import find_ui_update
+from ui.config_loader import load
+import os
+import logging
+from datetime import datetime
+import shutil
+import tarfile
+
+'''
+UI updater
+'''
+
+# setup the logs
+log_format = logging.Formatter(
+        '%(asctime)s - %(name)-16s - %(levelname)-8s - %(message)s')
+log = logging.getLogger('')
+log.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setFormatter(log_format)
+log.addHandler(ch)
+fh = logging.FileHandler('update.log')
+fh.setFormatter(log_format)
+log.addHandler(fh)
+
+'''
+checks the state, if state is set to in_progress, get the update file and continue
+'''
+log.info("checking state")
+process = Popen(["python", "ui/initial_state.py"], stdout=PIPE)
+(update_state, err) = process.communicate()
+exit_code = process.wait()
+
+if update_state is None:
+    log.warning("couldn't open state")
+    exit(1)
+
+update_state = update_state.strip()
+log.info("update_ui = %s" % update_state)
+if update_state != "in progress":
+    exit(0)
+
+config = load("ui/config.rc")
+update_file = find_ui_update(config)
+if update_file is None:
+    log.warning("no update file found")
+    exit(1)
+
+log.info("found update file: %s" % update_file)
+
+'''
+everything is ready, so:
+    * archive the ui directory in config's install_dir
+    * untar.gz new archive into place
+'''
+
+install_dir = config.get('files', 'install_dir')
+install_dir = os.path.expanduser(install_dir)
+
+archive_dir = config.get('files', 'archive_dir')
+archive_dir = os.path.expanduser(archive_dir)
+
+# archive old ui
+log.info("archiving %s to %s" % (install_dir, archive_dir))
+archive_dir += datetime.now().strftime("%Y%m%d-%H%M%S-ui")
+shutil.move(install_dir, archive_dir)
+
+# untar new ui
+log.info("untar to %s" % install_dir)
+with tarfile.open(update_file, 'r:*') as archive:
+    archive.extractall(install_dir)

--- a/update_ui.py
+++ b/update_ui.py
@@ -11,10 +11,10 @@ import tarfile
 config = load("ui/config.rc")
 log = setup_logs(config, logging.DEBUG)
 
-'''
-checks the state, if state is set to in_progress, get the update file and continue
-'''
 def need_update():
+    '''
+    checks the state, if state is set to in_progress, get the update file and continue
+    '''
     log.info("checking state")
     process = Popen(["python", "ui/initial_state.py"], stdout=PIPE)
     (update_state, err) = process.communicate()
@@ -30,11 +30,11 @@ def need_update():
         return True
 
 
-'''
-archive the ui directory in config's install_dir
-then untar.gz new archive into place
-'''
 def archive_and_untar():
+    '''
+    archive the ui directory in config's install_dir
+    then untar.gz new archive into place
+    '''
     install_dir = config.get('files', 'install_dir')
     install_dir = os.path.expanduser(install_dir)
 


### PR DESCRIPTION
* adds a new menu option to start process
* if canute-ui.tar.gz is found on usb stick UI update process starts:
    * stop button loop
    * archive old ui directory (archive_dir defined in config file)
    * untar new UI files to directory (install_dir defined in config file)
    * stops

## Notes

* the ui process needs to be run in a loop so that after halt and update it will start again.
* config.rc must be updated with install_dir and archive_dir
* tested with this loop:

 ```
   while true; do
        cd ui
        python main.py
        # cd out of the directory to allow the new changes to be visible
        cd ..
    done
```