### PR TITLE
Add installation instructions for emulator on mac

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,13 +1,35 @@
 # Install
 
-## Linux for testing
+## Linux/Mac for testing
 
-Install python 2.x (will probably work with 3.x with little modification)
+Install python 2.x (will probably work with 3.x with little modification).
 
-Install requirements:
+Install pip:
+For Debian/Ubuntu (and various other Linux distros)
 
-    sudo apt install python-pyside python-pip python-dev
-    pip install --user -r requirements.txt
+    sudo apt install python-pip    
+
+For Mac, depending on whether you are using the native python, MacPorts or Homebrew
+Mac native: `sudo easy_install pip`
+Macports: `sudo port install py27-pip`
+Homebrew: pip gets installed automatically when you install python.
+
+
+If you wish to run the emulator, install PySide, and optionally the Python development tools:
+```
+pip install pyside
+```
+
+(For Linux you may prefer to use)
+```
+sudo apt install python-pyside python-dev
+```
+
+Install other requirements: 
+(For the Mac, you will need to comment out the `evdev` line in `requirements.txt`)
+```
+pip install --user -r requirements.txt
+```
 
 Copy the test books to the home directory:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ Run the UI using the emulator:
     python main.py
 
 ## Mac (emulator only)
-For the Mac installation is slightly different depending on whether you use the version of python that comes with OS, or one installed with Macports or Homwbrew.
+For the Mac, installation is slightly different depending on whether you use the version of python that comes with OS, or one installed with Macports or Homwbrew.
 
 First, comment out (put a hash in front) of the `evdev` line in `requirements.txt`. (This package is only used on linux, and if you try to install it on a mac it will fail). 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,32 +1,15 @@
 # Install
 
-## Linux/Mac for testing
+## Linux for testing
 
 Install python 2.x (will probably work with 3.x with little modification).
 
-Install pip:
-For Debian/Ubuntu (and various other Linux distros)
-
-    sudo apt install python-pip    
-
-For Mac, depending on whether you are using the native python, MacPorts or Homebrew
-Mac native: `sudo easy_install pip`
-Macports: `sudo port install py27-pip`
-Homebrew: pip gets installed automatically when you install python.
-
-
-If you wish to run the emulator, install PySide, and optionally the Python development tools:
+Install pip and other dependencies:
 ```
-pip install pyside
-```
-
-(For Linux you may prefer to use)
-```
-sudo apt install python-pyside python-dev
+sudo apt install python-pip python-pyside python-dev
 ```
 
 Install other requirements: 
-(For the Mac, you will need to comment out the `evdev` line in `requirements.txt`)
 ```
 pip install --user -r requirements.txt
 ```
@@ -44,6 +27,50 @@ Run the UI using the emulator:
 
     cd ui/
     python main.py
+
+## Mac (emulator only)
+For the Mac installation is slightly different depending on whether you use the version of python that comes with OS, or one installed with Macports or Homwbrew.
+
+First, comment out (put a hash in front) of the `evdev` line in `requirements.txt`. (This package is only used on linux, and if you try to install it on a mac it will fail). 
+
+For native installation:
+```
+sudo easy_install pip
+pip install python-pyside
+pip install --user -r requirements.txt
+```
+
+For MacPorts:
+```
+sudo port install py27-pip py27-pyside
+pip install --user -r requirements.txt
+```
+
+For Homebrew:
+```
+brew install python brew-pip
+brew pip install python-pyside
+pip install --user -r requirements.txt
+```
+
+Then, to test and run it:
+
+Copy the test books to the home directory:
+
+    cp -r books ~/
+
+Run the tests:
+
+    cd ui/
+    python test.py --verbose
+
+Run the UI using the emulator:
+
+    cd ui/
+    python main.py
+
+
+
 
 ## Raspberry Pi
 


### PR DESCRIPTION
I wasn't sure when editing this: is "python-dev" actually used? It doesn't appear to be used for the emulator.