### PR TITLE
Fix reset state and add call to reset on startup

### DIFF
--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -49,6 +49,8 @@ def write(state):
     write_state['location']          = location
     write_state['backing_up_log']    = False
     write_state['replacing_library'] = False
+    write_state['resetting_display'] = False
+    write_state['warming_up']        = False
     write_state['shutting_down']     = False
     with open(state_file, 'w') as fh:
         pickle.dump(frozendict(write_state), fh)

--- a/ui/main.py
+++ b/ui/main.py
@@ -53,11 +53,11 @@ def main():
 def run(driver, config):
     init_state    = initial_state.read()
     width, height = driver.get_dimensions()
-    init_state    = init_state.copy(dimensions = frozendict({'width': width, 'height': height}))
+    init_state    = init_state.copy(dimensions = frozendict({'width': width, 'height': height}), resetting_display = 'start')
     store.dispatch(actions.init(init_state))
     sync_library(init_state, config.get('files', 'library_dir'))
     store.subscribe(partial(handle_changes, driver, config))
-    
+
     # if we startup and update_ui is still 'in progress' then we are using the old state file
     # and update has failed
     if init_state["update_ui"] == "in progress":
@@ -112,6 +112,10 @@ def render(driver, state):
         store.dispatch(actions.reset_display('in progress'))
         driver.reset_display()
         store.dispatch(actions.reset_display('done'))
+    elif state['warming_up'] == 'in progress' or state['resetting_display'] == 'in progress':
+        # our render method can be called asynchronously, we don't don anything
+        # unless these are done
+        pass
     elif state['warming_up'] == 'start':
         store.dispatch(actions.warm_up('in progress'))
         driver.warm_up()

--- a/ui/main.py
+++ b/ui/main.py
@@ -111,7 +111,7 @@ def render(driver, state):
     if state['resetting_display'] == 'start':
         store.dispatch(actions.reset_display('in progress'))
         driver.reset_display()
-        store.dispatch(actions.reset_display(False))
+        store.dispatch(actions.reset_display('done'))
     elif state['warming_up'] == 'start':
         store.dispatch(actions.warm_up('in progress'))
         driver.warm_up()

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -7,7 +7,6 @@ menu = OrderedDict([
     ('replace library from USB stick' , partial(actions.replace_library, 'start')),
     ('shutdown'                       , actions.shutdown),
     ('backup log to USB stick'        , partial(actions.backup_log, 'start')),
-    ('run warm up routine'            , partial(actions.warm_up, 'start')),
     ('reset display'                  , partial(actions.reset_display, 'start')),
     ('update UI from USB stick'       , partial(actions.update_ui, 'start')),
 ])


### PR DESCRIPTION
This fixes some issues regarding the reset state and adds a reset call on startup (which cannot be added to firmware at the moment).

Warm-up routine is still present but disabled as we are using a different approach for warming up at the moment. 