### PR TITLE
Make go_to_page back button deletes whole selection

### DIFF
--- a/ui/go_to_page/reducers.py
+++ b/ui/go_to_page/reducers.py
@@ -10,8 +10,8 @@ class GoToPageReducers():
 
         # handle delete ('<') characters
         r = re.compile('\d<')
-        while r.search(selection) is not None:
-            selection = r.sub('', selection)
+        if r.search(selection) is not None:
+            selection = ''
         # any left over delete characters after numbers are ignored
         selection = ''.join([c for c in selection if c != '<'])
 


### PR DESCRIPTION
Back button on go-to-page now deletes the whole entered number. Fixes #133. 