### PR TITLE
Detect potential USB B disconnection

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -85,13 +85,13 @@ def main():
     else:
         log.info('running with real hardware on port %s, timeout %s' %
                  (args.tty, timeout))
-        with Pi(port=args.tty, timeout=timeout) as driver:
-            try:
+        try:
+            with Pi(port=args.tty, timeout=timeout) as driver:
                 run(driver, config)
-            except RuntimeError as err:
-                if driver.initialised and err.args[0] == 'readFrame timeout':
-                    log.info('passthrough serial disconnected, USB B in use, exiting')
-                    sys.exit(2)
+        except RuntimeError as err:
+            if err.args[0] == 'readFrame timeout':
+                log.info('passthrough serial disconnected, USB B probably in use, exiting')
+                sys.exit(2)
 
 def run(driver, config):
     loop = asyncio.get_event_loop()
@@ -143,7 +143,6 @@ async def run_async(driver, config, loop):
     driver.reset_display()
     while not driver.is_motion_complete():
         await asyncio.sleep(0.01)
-    driver.initialised = True
     media_handler = asyncio.ensure_future(handle_media_changes())
     duty_logger = asyncio.ensure_future(driver.track_duty())
     media_dir = config.get('files', 'media_dir')


### PR DESCRIPTION
Following discussion, the code change now simply detects socket timeouts and returns an exit code of 2 when these happen.

This is indicative of the USB B port being used, but could also mean a slow start up - external logic is required to distinguish between the two cases.