### PR TITLE
Fix warm reset timeouts

### DIFF
--- a/ui/driver/driver_pi.py
+++ b/ui/driver/driver_pi.py
@@ -6,7 +6,6 @@ import logging
 import serial
 import serial.tools.list_ports
 import struct
-import zmq
 import smbus2
 from .. import braille
 
@@ -53,10 +52,6 @@ class Pi(Driver):
             self.port = None
 
         self.previous_buttons = tuple()
-
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.PUB)
-        self.socket.bind('tcp://*:%s' % LINE_PUBLISHING_PORT)
 
         self.row_actuations = [0] * N_ROWS
 
@@ -154,11 +149,20 @@ class Pi(Driver):
             if cmd == comms.CMD_SEND_LINE:
                 row = data[0]
                 self._log_row_actuation(row)
-                brl = ''.join([braille.pin_num_to_unicode(ch) for ch in data[1:]])
-                brf = ''.join(braille.pin_nums_to_alphas(data[1:]))
-                self.socket.send_pyobj({'line_number': row, 'visual': brf, 'braille': brl})
+                self._publish_line(row, data[1:])
 
             self.HDLC.sendFrame(payload)
+
+    def _publish_line(self, row, content):
+        if not hasattr(self, 'context'):
+            # defer this till needed as it slows startup
+            import zmq
+            self.context = zmq.Context()
+            self.socket = self.context.socket(zmq.PUB)
+            self.socket.bind('tcp://*:%s' % LINE_PUBLISHING_PORT)
+        brl = ''.join([braille.pin_num_to_unicode(ch) for ch in content])
+        brf = ''.join(braille.pin_nums_to_alphas(content))
+        self.socket.send_pyobj({'line_number': row, 'visual': brf, 'braille': brl})
 
     async def async_get_data(self, expected_cmd):
         '''gets 2 bytes of data from the hardware
@@ -273,7 +277,7 @@ class Pi(Driver):
         if self.port:
             log.error('closing serial port')
             self.port.close()
-        if self.context:
+        if hasattr(self, 'context'):
             self.context.destroy()
         if hasattr(self, 'button_thread'):
             self.button_thread.join()

--- a/ui/driver/driver_pi.py
+++ b/ui/driver/driver_pi.py
@@ -155,7 +155,7 @@ class Pi(Driver):
 
     def _publish_line(self, row, content):
         if not hasattr(self, 'context'):
-            # defer this till needed as it slows startup
+            # defer this 'til needed as it slows startup
             import zmq
             self.context = zmq.Context()
             self.socket = self.context.socket(zmq.PUB)

--- a/ui/main.py
+++ b/ui/main.py
@@ -260,10 +260,8 @@ async def handle_hardware(driver, state, store, media_dir):
         # Wait for reset to complete so that upon respawn SEND_LINEs
         # don't get ignored/rejected.
         log.warning('long-press of square: issued reset, exiting')
-        time.sleep(8)
-        while driver.port.inWaiting():
-            c = driver.port.read()
-            log.warning('discard %s' % c)
+        while not driver.is_motion_complete():
+            await asyncio.sleep(0.01)
         sys.exit(0)
     elif state['hardware']['warming_up'] == 'start':
         store.dispatch(actions.warm_up('in progress'))

--- a/ui/main.py
+++ b/ui/main.py
@@ -142,6 +142,14 @@ async def run_async(driver, config, loop):
     # while they're resetting, have the UI issue a reset as its first
     # act, synchronously.
     driver.reset_display()
+
+    # process these imports while resetting as they are slow
+    import aioredux
+    import aioredux.middleware
+    from . import buttons
+    from .store import main_reducer
+    from .book.handlers import load_books
+
     while not driver.is_motion_complete():
         await asyncio.sleep(0.01)
     media_handler = asyncio.ensure_future(handle_media_changes())
@@ -151,13 +159,6 @@ async def run_async(driver, config, loop):
     width, height = driver.get_dimensions()
     state = state.copy(app=state['app'].copy(
         display=frozendict({'width': width, 'height': height})))
-
-    # defer these imports as they are slow
-    import aioredux
-    import aioredux.middleware
-    from . import buttons
-    from .store import main_reducer
-    from .book.handlers import load_books
 
     thunk_middleware = aioredux.middleware.thunk_middleware
     create_store = aioredux.apply_middleware(

--- a/ui/main.py
+++ b/ui/main.py
@@ -256,12 +256,7 @@ async def handle_hardware(driver, state, store, media_dir):
             return False
         return True
     elif state['hardware']['resetting_display'] == 'start':
-        driver.reset_display()
-        # Wait for reset to complete so that upon respawn SEND_LINEs
-        # don't get ignored/rejected.
-        log.warning('long-press of square: issued reset, exiting')
-        while not driver.is_motion_complete():
-            await asyncio.sleep(0.01)
+        log.warning('long-press of square: exiting to cause reset')
         sys.exit(0)
     elif state['hardware']['warming_up'] == 'start':
         store.dispatch(actions.warm_up('in progress'))


### PR DESCRIPTION
Fix #281 by removing the reset from this session of canute-ui and just exiting.  When the ui respawns it will run a reset anyway.

This feels slower to react to the end user, as it used to start resetting immediately - but actually is quicker overall because it no longer does two resets for each button press.

This PR includes moving some expensive and slow python imports to be done after the reset has started, which overall increases the startup speed.  (This should also help increase the 'spotting USB B unplug and shutdown' speed too.)