### PR TITLE
Store current book state on usb, as well as sd card, if present

### DIFF
--- a/config.rc.in
+++ b/config.rc.in
@@ -8,10 +8,10 @@ media_dir = /media
 sd_card_dir = sd-card
 
 # Additional books made available on the USB ports will (for now at
-# least) be visible in the library.  Further, in the absence of a state
-# file on the SD card, a state file on a USB medium will get read (but
-# will not be updated).  Neither of these behaviours are officially
-# supported and they may change at any time so shouldn't be relied upon.
+# least) be visible in the library.  The current state will be written
+# to all mount points that are active, however the state file on the
+# SD card will take precedence, followed by lib_1 and finally lib_2.
+# These behaviours may change at any time so shouldn't be relied upon.
 #
 # These paths are relative to media_dir.
 # These config values are optional.

--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -71,28 +71,35 @@ def to_state_file(book_path):
     dirname = os.path.dirname(book_path)
     return os.path.join(dirname, 'canute.' + basename + '.txt')
 
-
-async def read_user_state(path):
-    global prev
-    global manual
-    current_book = manual_filename
-    current_language = None
-    book_files = utility.find_files(path, ('brf', 'pef'))
+def mounted_source_paths(media_dir):
     config = config_loader.load()
     state_sources = ['sd_card_dir']
     if config.has_option('files', 'additional_lib_1'):
         state_sources.append('additional_lib_1')
     if config.has_option('files', 'additional_lib_2'):
         state_sources.append('additional_lib_2')
-    for state_source in state_sources:
-        _dir = config.get('files', state_source)
-        main_toml = os.path.join(path, _dir, USER_STATE_FILE)
+
+    for source in state_sources:
+        source_dir = config.get('files', source)
+        source_path = os.path.join(media_dir, source_dir)
+        if os.path.ismount(source_path):
+            yield source_path
+
+async def read_user_state(media_dir):
+    global prev
+    global manual
+    current_book = manual_filename
+    current_language = None
+    book_files = utility.find_files(media_dir, ('brf', 'pef'))
+    source_paths = mounted_source_paths(media_dir)
+    for source_path in source_paths:
+        main_toml = os.path.join(source_path, USER_STATE_FILE)
         if os.path.exists(main_toml):
             main_state = toml.load(main_toml)
             if 'current_book' in main_state:
                 current_book = main_state['current_book']
                 if not current_book == manual_filename:
-                    current_book = os.path.join(path, current_book)
+                    current_book = os.path.join(media_dir, current_book)
             if 'current_language' in main_state:
                 current_language = main_state['current_language']
             break
@@ -103,7 +110,7 @@ async def read_user_state(path):
     install(current_language)
     manual = Manual.create()
 
-    manual_toml = os.path.join(path, to_state_file(manual_filename))
+    manual_toml = os.path.join(media_dir, to_state_file(manual_filename))
     if os.path.exists(manual_toml):
         t = toml.load(manual_toml)
         if 'current_page' in t:
@@ -135,8 +142,8 @@ async def read_user_state(path):
     return user_state.copy(books=user_state['books'])
 
 
-async def read(path):
-    user_state = await read_user_state(path)
+async def read(media_dir):
+    user_state = await read_user_state(media_dir)
     return initial_state.copy(app=initial_state['app'].copy(user=user_state))
 
 
@@ -153,11 +160,12 @@ async def write(store, media_dir, sem, writes_in_flight):
             selected_book = os.path.relpath(selected_book, media_dir)
         s = toml.dumps({'current_book': selected_book,
                         'current_language': selected_lang})
-        config = config_loader.load()
-        sd_card_dir = config.get('files', 'sd_card_dir')
-        path = os.path.join(media_dir, sd_card_dir, USER_STATE_FILE)
-        async with aiofiles.open(path, 'w') as f:
-            await f.write(s)
+        source_paths = mounted_source_paths(media_dir)
+        for source_path in source_paths:
+            path = os.path.join(source_path, USER_STATE_FILE)
+            async with aiofiles.open(path, 'w') as f:
+                await f.write(s)
+            
     for filename in books:
         book = books[filename]
         if filename in prev['books']:

--- a/ui/initial_state.py
+++ b/ui/initial_state.py
@@ -95,14 +95,17 @@ async def read_user_state(media_dir):
     for source_path in source_paths:
         main_toml = os.path.join(source_path, USER_STATE_FILE)
         if os.path.exists(main_toml):
-            main_state = toml.load(main_toml)
-            if 'current_book' in main_state:
-                current_book = main_state['current_book']
-                if not current_book == manual_filename:
-                    current_book = os.path.join(media_dir, current_book)
-            if 'current_language' in main_state:
-                current_language = main_state['current_language']
-            break
+            try:
+                main_state = toml.load(main_toml)
+                if 'current_book' in main_state:
+                    current_book = main_state['current_book']
+                    if not current_book == manual_filename:
+                        current_book = os.path.join(media_dir, current_book)
+                if 'current_language' in main_state:
+                    current_language = main_state['current_language']
+                break
+            except Exception:
+                log.warning('user state loading failed for {}, ignoring'.format(main_toml))
 
     if not current_language or current_language == OLD_DEFAULT_LOCALE:
         current_language = DEFAULT_LOCALE.code
@@ -112,24 +115,31 @@ async def read_user_state(media_dir):
 
     manual_toml = os.path.join(media_dir, to_state_file(manual_filename))
     if os.path.exists(manual_toml):
-        t = toml.load(manual_toml)
-        if 'current_page' in t:
-            manual = manual._replace(page_number=t['current_page'] - 1)
-        if 'bookmarks' in t:
-            manual = manual._replace(bookmarks=tuple(sorted(manual.bookmarks + tuple(
-                bm - 1 for bm in t['bookmarks']))))
+        try:
+            t = toml.load(manual_toml)
+            if 'current_page' in t:
+                manual = manual._replace(page_number=t['current_page'] - 1)
+            if 'bookmarks' in t:
+                manual = manual._replace(bookmarks=tuple(sorted(manual.bookmarks + tuple(
+                    bm - 1 for bm in t['bookmarks']))))
+        except Exception:
+            log.warning('manual state loading failed for {}, ignoring'.format(manual_toml))
 
     books = OrderedDict({manual_filename: manual})
     for book_file in book_files:
         toml_file = to_state_file(book_file)
         book = BookFile(filename=book_file, width=40, height=9)
         if os.path.exists(toml_file):
-            t = toml.load(toml_file)
-            if 'current_page' in t:
-                book = book._replace(page_number=t['current_page'] - 1)
-            if 'bookmarks' in t:
-                book = book._replace(bookmarks=tuple(sorted(book.bookmarks + tuple(
-                    bm - 1 for bm in t['bookmarks']))))
+            try:
+                t = toml.load(toml_file)
+                if 'current_page' in t:
+                    book = book._replace(page_number=t['current_page'] - 1)
+                if 'bookmarks' in t:
+                    book = book._replace(bookmarks=tuple(sorted(book.bookmarks + tuple(
+                        bm - 1 for bm in t['bookmarks']))))
+            except Exception:
+                log.warning('book state loading failed for {}, ignoring'.format(toml_file))
+
         books[book_file] = book
     books[cleaning_filename] = CleaningAndTesting.create()
 


### PR DESCRIPTION
This PR writes the current book information to any USB medium that is currently inserted in addition to (or instead of) the SD card.

The state is read in preference from the SD card, then the front, and then the back USB ports in that order (under normal configuration).

[It might be possible to check timestamps to see which is the 'most recent' in this situation, but the unit is not network connected, so I am unsure whether that would work.]

Because the state file remembers the mount point, as well as the current book's filename, the PR also includes an extra bit of code to check the other port in case the user plugs their USB stick/thumb drive into a different port.

This PR also includes slightly more tolerant error checking should any of the state files be corrupt in any way - if they aren't understood, they will just be ignored.

Fixes #283 