### PR TITLE
Optimise book indexing

### DIFF
--- a/ui/book/handlers.py
+++ b/ui/book/handlers.py
@@ -50,6 +50,8 @@ async def _read_pages2(book, background=False):
         else:
             os.set_blocking(r, True)
             buf = os.read(r, 10)
+        os.close(r)
+        os.close(w)
         if buf != b'ok':
             raise BookFileError(
                 'loading failed: {}'.format(book.filename))

--- a/ui/book/handlers.py
+++ b/ui/book/handlers.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import re
 import os
-import xml.etree.cElementTree as ElementTree
 
 from ..manual import manual_filename
 from .. import braille

--- a/ui/book/state.py
+++ b/ui/book/state.py
@@ -1,4 +1,3 @@
-import os
 from collections import OrderedDict
 
 from .book_file import LoadState

--- a/ui/library/state.py
+++ b/ui/library/state.py
@@ -1,7 +1,6 @@
 import os
 import math
 import logging
-from collections import OrderedDict
 
 from ..book import book_file
 from .. import state

--- a/ui/library/view.py
+++ b/ui/library/view.py
@@ -94,13 +94,7 @@ def render_library(width, height, state):
     library = state.app.library
     page_num = library.page
 
-    begin = 0
-    end = library.DIRS_PAGE_SIZE
-    if library.files_page_open:
-        if page_num == library._files_page_start - 1:
-            end = library.files_dir_index % library.DIRS_PAGE_SIZE + 1
-        if page_num == library._files_page_start + library._files_pages:
-            begin = library.files_dir_index % library.DIRS_PAGE_SIZE
+    begin, end = library.page_begin_end(page_num)
 
     if library._is_files_page(page_num):
         page_num -= library._files_page_start

--- a/ui/library/view.py
+++ b/ui/library/view.py
@@ -73,7 +73,8 @@ def page_display_text(dir, page, of_pages, width):
     title = unicodes_to_alphas(_('library menu'))
     progress = f'{to_ueb_number(page)}/{to_ueb_number(of_pages)}'
     if dir is not None:
-        title += ' - ' + truncate_location(dir.display_relpath, width - len(title) - 3 - len(progress) - 3)
+        title += ' - ' + truncate_location(dir.display_relpath,
+                                           width - len(title) - 3 - len(progress) - 3)
     title += ' ' + (width - len(title) - len(progress) - 2) * '-' + ' ' + progress
     return from_ascii(title)
 

--- a/ui/main.py
+++ b/ui/main.py
@@ -248,7 +248,7 @@ def handle_display_events(config, state):
 
     async def load_render_cache():
         now, later = state.app.library.books_to_index()
-        
+
         # make sure we have all the info we need and then display
         for book in now:
             await load_book(book, state)
@@ -261,7 +261,7 @@ def handle_display_events(config, state):
                 continue
             queue.task_done()
 
-        # now queue up indexing tasks to cache 
+        # now queue up indexing tasks to cache
         for book in later:
             queue.put_nowait(book.relpath(media_dir))
 

--- a/ui/state.py
+++ b/ui/state.py
@@ -26,7 +26,7 @@ class StateEvent(object):
 
     def __call__(self, *args, **kwargs):
         for handler in self.handlers:
-            res = handler(*args, **kwargs)
+            handler(*args, **kwargs)
 
 
 class HelpState:

--- a/ui/state.py
+++ b/ui/state.py
@@ -12,7 +12,7 @@ from .go_to_page.view import render_help as render_gtp_help
 from .bookmarks.help import render_help as render_bookmarks_help
 
 
-class Event(object):
+class StateEvent(object):
     def __init__(self):
         self.handlers = []
 
@@ -26,7 +26,7 @@ class Event(object):
 
     def __call__(self, *args, **kwargs):
         for handler in self.handlers:
-            handler(*args, **kwargs)
+            res = handler(*args, **kwargs)
 
 
 class HelpState:
@@ -231,9 +231,9 @@ class RootState:
         self.app = AppState(self)
         self.hardware = HardwareState(self)
 
-        self.refresh_display = Event()
-        self.save_state = Event()
-        self.backup_log = Event()
+        self.refresh_display = StateEvent()
+        self.save_state = StateEvent()
+        self.backup_log = StateEvent()
 
 
 state = RootState()


### PR DESCRIPTION
Currently the Canute tries to index (calculates page counts) for every book on any media it is given access to - for very large libraries on high capacity SD cards, this either fails or slows the machine down unacceptably.

This PR changes the approach to index books on more of a 'just in time' basis.

The approach taken is, before any display refresh to: work out which books are needed now and to index them immediately; and to work out which books are one button press away and to schedule a worker to index them at the next opportunity.  The information about any indexed books is cached in memory so it won't need to be done again in any particular session.

Approximately, there are three scenarios for this:

   1. If a library directory page is being shown, the first page of books in any subdirectory is indexed later 
   2. if a library files page is being shown, then the books on that specific page are indexed immediately, and the pages before and after it are indexed later
   3. if any other UI page is being shown, the current book is indexed immediately, and the books in its directory that are on its library page are indexed later

This codes also:
   * changes the book dictionary to use the relative (rather than full) path to the books as the key
   * and fixes an issue where the indexing task was leaking open file descriptors