### PR TITLE
Build 64-bit and 32-bit bookindex libraries

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,9 @@
 [target.arm-unknown-linux-gnueabihf]
-linker = "/rpi_tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc"
+linker = "/usr/bin/arm-linux-gnueabihf-gcc"
+# Strip the ARM library to shave off some load milliseconds.
+rustflags = [ "-C", "link-arg=-s" ]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "/usr/bin/aarch64-linux-gnu-gcc"
 # Strip the ARM library to shave off some load milliseconds.
 rustflags = [ "-C", "link-arg=-s" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,14 @@ jobs:
     - name: Build library
       run: |
         docker run -t -u "$(id -u):$(id -g)" -e "HOME=/work" -w /work -v "$PWD:/work" bristol-braille/bookindex:latest
-        mv target/arm-unknown-linux-gnueabihf/release/libbookindex.so .
+        mkdir lib
+        mv target/arm-unknown-linux-gnueabihf/release/libbookindex.so lib/
+        mkdir lib64
+        mv target/aarch64-unknown-linux-gnu/release/libbookindex.so lib64/
     - name: Create version file
       run: echo "$GITHUB_REF_NAME" > VERSION
     - name: Make tarball
-      run: tar czvf canute-ui.tar.gz --transform "s,^,canute-ui-$GITHUB_REF_NAME/," README.md LICENSE requirements-pi.txt canute_ui ui libbookindex.so config.rc.in run.sh books VERSION
+      run: tar czvf canute-ui.tar.gz --transform "s,^,canute-ui-$GITHUB_REF_NAME/," README.md LICENSE requirements-pi.txt canute_ui ui lib lib64 config.rc.in run.sh books VERSION
     - name: Release (if tagged)
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - wget https://github.com/Bristol-Braille/canute-ui-rust/releases/latest/download/libbookindex.so
 
 script:
-  - LD_LIBRARY_PATH=. ./test
+  - LD_LIBRARY_PATH=lib:lib64 ./test
   - ./lint
   - mkdir ~/canute-media && cp -r books ~/canute-media/sd-card && cp config.rc.travis config.rc
-  - LD_LIBRARY_PATH=. ./canute_ui --fuzz 550
+  - LD_LIBRARY_PATH=lib:lib64 ./canute_ui --fuzz 550

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,34 +4,18 @@ FROM --platform=linux/amd64 rust:slim-bullseye
 
 # Prevent any error messages about there not being a terminal
 ENV DEBIAN_FRONTEND noninteractive
-# Allow pkg-config to find 
-ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig
-# RPI tools dir
-ENV RPI_TOOLS=/rpi_tools
 
-# Enable the armhf arch
-RUN dpkg --add-architecture armhf
 RUN apt-get update -qq && \
-    # Install the necessary packages
-    # libudev-dev will also bring in the arm libc6 and gcc packages
-    apt-get install -qq --no-install-recommends git pkg-config libudev-dev:armhf && \
-    # Add the RPI toolchain
-    git -C "/" clone -q --depth=1 https://github.com/raspberrypi/tools.git "${RPI_TOOLS}" && \
-    # Remove most of the repo we just downloaded as we only need a small amount
-    rm -fr "${RPI_TOOLS}/.git" \
-           "${RPI_TOOLS}/arm-bcm2708/arm-bcm2708-linux-gnueabi" \
-           "${RPI_TOOLS}/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi" \
-           "${RPI_TOOLS}/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian" \
-           "${RPI_TOOLS}/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64" && \
-    # Then get rid of git as we only needed it to fetch the rpi tools
-    apt-get purge -qq git && \
+    # Install the necessary packages to build & cross compile
+    apt-get install -qq --no-install-recommends pkg-config libc6-dev-armhf-cross gcc-arm-linux-gnueabihf libc6-dev-arm64-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross && \
     # Purge anything that has become useless
     apt-get autoremove -qq --purge && \
     # And finally do cleanup
     apt-get clean -qq && rm -fr /var/lib/apt/* /var/cache/apt/*
 
-# Enable arm v6 in Rust
+# Enable arm v6 and aarch64 in Rust
 RUN rustup target add arm-unknown-linux-gnueabihf
+RUN rustup target add aarch64-unknown-linux-gnu
 
-CMD cargo build --release --target=arm-unknown-linux-gnueabihf
-# CMD /rpi_tools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -v
+CMD PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig cargo build --release --target=arm-unknown-linux-gnueabihf && \
+    PKG_CONFIG_PATH=/usr/libaarch64-linux-gnu/pkgconfig cargo build --release --target=aarch64-unknown-linux-gnu

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN rustup target add arm-unknown-linux-gnueabihf
 RUN rustup target add aarch64-unknown-linux-gnu
 
 CMD PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig cargo build --release --target=arm-unknown-linux-gnueabihf && \
-    PKG_CONFIG_PATH=/usr/libaarch64-linux-gnu/pkgconfig cargo build --release --target=aarch64-unknown-linux-gnu
+    PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig cargo build --release --target=aarch64-unknown-linux-gnu


### PR DESCRIPTION
This PR removes the dependency on the deprecated [RPI_TOOLS](https://github.com/raspberrypi/tools) and builds both a 32-bit armv6 and 64-bit aarch64 version of the library for use on more modern RPis.

Note that the libraries have been moved into a `lib/` and `lib64/` folder for ease of use with `LD_LIBRARY_PATH`.